### PR TITLE
Fix typo in 'yðr'

### DIFF
--- a/json/zoega-no-markup.json
+++ b/json/zoega-no-markup.json
@@ -186202,7 +186202,7 @@
   {
     "word": "yðr",
     "definitions": [
-      "pron., dat. and ace. pl. you."
+      "pron., dat. and acc. pl. you."
     ]
   },
   {


### PR DESCRIPTION
Fix the typo 'ace' instead of 'acc' in 'yðr'.